### PR TITLE
Fix "The `ember generate <entity-name>` command

### DIFF
--- a/blueprints/ember-frost-viz/index.js
+++ b/blueprints/ember-frost-viz/index.js
@@ -2,7 +2,7 @@ module.exports = {
   description: '',
 
   normalizeEntityName: function () {},
-  
+
   afterInstall: function () {
     return this.addAddonsToProject({
       packages: [

--- a/blueprints/ember-frost-viz/index.js
+++ b/blueprints/ember-frost-viz/index.js
@@ -1,6 +1,8 @@
 module.exports = {
   description: '',
 
+  normalizeEntityName: function () {},
+  
   afterInstall: function () {
     return this.addAddonsToProject({
       packages: [


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* Fix "The `ember generate <entity-name>` command requires an entity name to be specified." error during installation