### PR TITLE
Updated usage of deprecated describeComponent()

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "ember-resolver": "^2.0.3",
     "ember-sinon": "0.5.1",
     "ember-spread": "1.0.0",
-    "ember-test-utils": "1.3.2",
+    "ember-test-utils": "^1.10.3",
     "ember-truth-helpers": "1.2.0",
     "eslint": "^3.0.0",
     "eslint-config-frost-standard": "^5.0.0",

--- a/tests/integration/components/frost-viz/chart-test.js
+++ b/tests/integration/components/frost-viz/chart-test.js
@@ -1,30 +1,25 @@
 /* jshint expr:true */
-import { expect } from 'chai'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
+import {expect} from 'chai'
 import hbs from 'htmlbars-inline-precompile'
+import {describe, it} from 'mocha'
 
-describeComponent(
-  'frost-viz/chart',
-  'Integration: FrostVizChartComponent',
-  {
-    integration: true
-  },
-  function () {
-    it('renders', function () {
-      // Set any properties with this.set('myProperty', 'value');
-      // Handle any actions with this.on('myAction', function(val) { ... });
-      // Template block usage:
-      // this.render(hbs`
-      //   {{#frost-viz/chart}}
-      //     template content
-      //   {{/frost-viz/chart}}
-      // `);
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
-      this.render(hbs`{{frost-viz/chart}}`)
-      expect(this.$()).to.have.length(1)
-    })
-  }
-)
+const test = integration('frost-viz/chart')
+describe(test.label, function () {
+  test.setup()
+
+  it('renders', function () {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
+    // Template block usage:
+    // this.render(hbs`
+    //   {{#frost-viz/chart}}
+    //     template content
+    //   {{/frost-viz/chart}}
+    // `);
+
+    this.render(hbs`{{frost-viz/chart}}`)
+    expect(this.$()).to.have.length(1)
+  })
+})

--- a/tests/integration/components/frost-viz/plot/element/line-segment-test.js
+++ b/tests/integration/components/frost-viz/plot/element/line-segment-test.js
@@ -1,30 +1,25 @@
 /* jshint expr:true */
-import { expect } from 'chai'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
+import {expect} from 'chai'
 import hbs from 'htmlbars-inline-precompile'
+import {describe, it} from 'mocha'
 
-describeComponent(
-  'frost-viz/plot/element/line-segment',
-  'Integration: FrostVizPlotElementLineSegmentComponent',
-  {
-    integration: true
-  },
-  function () {
-    it('renders', function () {
-      // Set any properties with this.set('myProperty', 'value');
-      // Handle any actions with this.on('myAction', function(val) { ... });
-      // Template block usage:
-      // this.render(hbs`
-      //   {{#frost-viz/plot/element/line-segment}}
-      //     template content
-      //   {{/frost-viz/plot/element/line-segment}}
-      // `);
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
-      this.render(hbs`{{frost-viz/plot/element/line-segment}}`)
-      expect(this.$()).to.have.length(1)
-    })
-  }
-)
+const test = integration('frost-viz/plot/element/line-segment')
+describe(test.label, function () {
+  test.setup()
+
+  it('renders', function () {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
+    // Template block usage:
+    // this.render(hbs`
+    //   {{#frost-viz/plot/element/line-segment}}
+    //     template content
+    //   {{/frost-viz/plot/element/line-segment}}
+    // `);
+
+    this.render(hbs`{{frost-viz/plot/element/line-segment}}`)
+    expect(this.$()).to.have.length(1)
+  })
+})

--- a/tests/integration/components/frost-viz/plot/element/symbol/circle-test.js
+++ b/tests/integration/components/frost-viz/plot/element/symbol/circle-test.js
@@ -1,30 +1,25 @@
 /* jshint expr:true */
-import { expect } from 'chai'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
+import {expect} from 'chai'
 import hbs from 'htmlbars-inline-precompile'
+import {describe, it} from 'mocha'
 
-describeComponent(
-  'frost-viz/plot/element/symbol/circle',
-  'Integration: FrostVizPlotElementSymbolCircleComponent',
-  {
-    integration: true
-  },
-  function () {
-    it('renders', function () {
-      // Set any properties with this.set('myProperty', 'value');
-      // Handle any actions with this.on('myAction', function(val) { ... });
-      // Template block usage:
-      // this.render(hbs`
-      //   {{#frost-viz/plot/element/symbol/circle}}
-      //     template content
-      //   {{/frost-viz/plot/element/symbol/circle}}
-      // `);
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
-      this.render(hbs`{{frost-viz/plot/element/symbol/circle}}`)
-      expect(this.$()).to.have.length(1)
-    })
-  }
-)
+const test = integration('frost-viz/plot/element/symbol/circle')
+describe(test.label, function () {
+  test.setup()
+
+  it('renders', function () {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
+    // Template block usage:
+    // this.render(hbs`
+    //   {{#frost-viz/plot/element/symbol/circle}}
+    //     template content
+    //   {{/frost-viz/plot/element/symbol/circle}}
+    // `);
+
+    this.render(hbs`{{frost-viz/plot/element/symbol/circle}}`)
+    expect(this.$()).to.have.length(1)
+  })
+})

--- a/tests/integration/components/frost-viz/plot/element/symbol/star-test.js
+++ b/tests/integration/components/frost-viz/plot/element/symbol/star-test.js
@@ -1,30 +1,25 @@
 /* jshint expr:true */
-import { expect } from 'chai'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
+import {expect} from 'chai'
 import hbs from 'htmlbars-inline-precompile'
+import {describe, it} from 'mocha'
 
-describeComponent(
-  'frost-viz/plot/element/symbol/star',
-  'Integration: FrostVizPlotElementSymbolStarComponent',
-  {
-    integration: true
-  },
-  function () {
-    it('renders', function () {
-      // Set any properties with this.set('myProperty', 'value');
-      // Handle any actions with this.on('myAction', function(val) { ... });
-      // Template block usage:
-      // this.render(hbs`
-      //   {{#frost-viz/plot/element/symbol/star}}
-      //     template content
-      //   {{/frost-viz/plot/element/symbol/star}}
-      // `);
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
-      this.render(hbs`{{frost-viz/plot/element/symbol/star}}`)
-      expect(this.$()).to.have.length(1)
-    })
-  }
-)
+const test = integration('frost-viz/plot/element/symbol/star')
+describe(test.label, function () {
+  test.setup()
+
+  it('renders', function () {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
+    // Template block usage:
+    // this.render(hbs`
+    //   {{#frost-viz/plot/element/symbol/star}}
+    //     template content
+    //   {{/frost-viz/plot/element/symbol/star}}
+    // `);
+
+    this.render(hbs`{{frost-viz/plot/element/symbol/star}}`)
+    expect(this.$()).to.have.length(1)
+  })
+})

--- a/tests/integration/components/frost-viz/plot/line-test.js
+++ b/tests/integration/components/frost-viz/plot/line-test.js
@@ -1,30 +1,25 @@
 /* jshint expr:true */
-import { expect } from 'chai'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
+import {expect} from 'chai'
 import hbs from 'htmlbars-inline-precompile'
+import {describe, it} from 'mocha'
 
-describeComponent(
-  'frost-viz/plot/line',
-  'Integration: FrostVizPlotLineComponent',
-  {
-    integration: true
-  },
-  function () {
-    it.skip('renders', function () {
-      // Set any properties with this.set('myProperty', 'value');
-      // Handle any actions with this.on('myAction', function(val) { ... });
-      // Template block usage:
-      // this.render(hbs`
-      //   {{#frost-viz/plot/line}}
-      //     template content
-      //   {{/frost-viz/plot/line}}
-      // `);
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
-      this.render(hbs`{{frost-viz/plot/line}}`)
-      expect(this.$()).to.have.length(1)
-    })
-  }
-)
+const test = integration('frost-viz/plot/line')
+describe(test.label, function () {
+  test.setup()
+
+  it.skip('renders', function () {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
+    // Template block usage:
+    // this.render(hbs`
+    //   {{#frost-viz/plot/line}}
+    //     template content
+    //   {{/frost-viz/plot/line}}
+    // `);
+
+    this.render(hbs`{{frost-viz/plot/line}}`)
+    expect(this.$()).to.have.length(1)
+  })
+})

--- a/tests/integration/components/frost-viz/plot/path-test.js
+++ b/tests/integration/components/frost-viz/plot/path-test.js
@@ -1,30 +1,25 @@
 /* jshint expr:true */
-import { expect } from 'chai'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
+import {expect} from 'chai'
 import hbs from 'htmlbars-inline-precompile'
+import {describe, it} from 'mocha'
 
-describeComponent(
-  'frost-viz/plot/path',
-  'Integration: FrostVizPlotPathComponent',
-  {
-    integration: true
-  },
-  function () {
-    it('renders', function () {
-      // Set any properties with this.set('myProperty', 'value');
-      // Handle any actions with this.on('myAction', function(val) { ... });
-      // Template block usage:
-      // this.render(hbs`
-      //   {{#frost-viz/plot/path}}
-      //     template content
-      //   {{/frost-viz/plot/path}}
-      // `);
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
-      this.render(hbs`{{frost-viz/plot/path}}`)
-      expect(this.$()).to.have.length(1)
-    })
-  }
-)
+const test = integration('frost-viz/plot/path')
+describe(test.label, function () {
+  test.setup()
+
+  it('renders', function () {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
+    // Template block usage:
+    // this.render(hbs`
+    //   {{#frost-viz/plot/path}}
+    //     template content
+    //   {{/frost-viz/plot/path}}
+    // `);
+
+    this.render(hbs`{{frost-viz/plot/path}}`)
+    expect(this.$()).to.have.length(1)
+  })
+})

--- a/tests/integration/components/frost-viz/plot/scatter-test.js
+++ b/tests/integration/components/frost-viz/plot/scatter-test.js
@@ -1,30 +1,25 @@
 /* jshint expr:true */
-import { expect } from 'chai'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
+import {expect} from 'chai'
 import hbs from 'htmlbars-inline-precompile'
+import {describe, it} from 'mocha'
 
-describeComponent(
-  'frost-viz/plot/scatter',
-  'Integration: FrostVizPlotScatterComponent',
-  {
-    integration: true
-  },
-  function () {
-    it.skip('renders', function () {
-      // Set any properties with this.set('myProperty', 'value');
-      // Handle any actions with this.on('myAction', function(val) { ... });
-      // Template block usage:
-      // this.render(hbs`
-      //   {{#frost-viz/plot/scatter}}
-      //     template content
-      //   {{/frost-viz/plot/scatter}}
-      // `);
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
-      this.render(hbs`{{frost-viz/plot/scatter}}`)
-      expect(this.$()).to.have.length(1)
-    })
-  }
-)
+const test = integration('frost-viz/plot/scatter')
+describe(test.label, function () {
+  test.setup()
+
+  it.skip('renders', function () {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
+    // Template block usage:
+    // this.render(hbs`
+    //   {{#frost-viz/plot/scatter}}
+    //     template content
+    //   {{/frost-viz/plot/scatter}}
+    // `);
+
+    this.render(hbs`{{frost-viz/plot/scatter}}`)
+    expect(this.$()).to.have.length(1)
+  })
+})

--- a/tests/integration/components/frost-viz/scale-test.js
+++ b/tests/integration/components/frost-viz/scale-test.js
@@ -1,30 +1,25 @@
 /* jshint expr:true */
-import { expect } from 'chai'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
+import {expect} from 'chai'
 import hbs from 'htmlbars-inline-precompile'
+import {describe, it} from 'mocha'
 
-describeComponent(
-  'frost-viz/scale',
-  'Integration: FrostVizScaleComponent',
-  {
-    integration: true
-  },
-  function () {
-    it.skip('renders', function () {
-      // Set any properties with this.set('myProperty', 'value');
-      // Handle any actions with this.on('myAction', function(val) { ... });
-      // Template block usage:
-      // this.render(hbs`
-      //   {{#frost-viz/scale}}
-      //     template content
-      //   {{/frost-viz/scale}}
-      // `);
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
-      this.render(hbs`{{frost-viz/scale}}`)
-      expect(this.$()).to.have.length(1)
-    })
-  }
-)
+const test = integration('frost-viz/scale')
+describe(test.label, function () {
+  test.setup()
+
+  it.skip('renders', function () {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
+    // Template block usage:
+    // this.render(hbs`
+    //   {{#frost-viz/scale}}
+    //     template content
+    //   {{/frost-viz/scale}}
+    // `);
+
+    this.render(hbs`{{frost-viz/scale}}`)
+    expect(this.$()).to.have.length(1)
+  })
+})

--- a/tests/integration/components/frost-viz/scale/tick-test.js
+++ b/tests/integration/components/frost-viz/scale/tick-test.js
@@ -1,30 +1,25 @@
 /* jshint expr:true */
-import { expect } from 'chai'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
+import {expect} from 'chai'
 import hbs from 'htmlbars-inline-precompile'
+import {describe, it} from 'mocha'
 
-describeComponent(
-  'frost-viz/scale/tick',
-  'Integration: FrostVizScaleTickComponent',
-  {
-    integration: true
-  },
-  function () {
-    it('renders', function () {
-      // Set any properties with this.set('myProperty', 'value');
-      // Handle any actions with this.on('myAction', function(val) { ... });
-      // Template block usage:
-      // this.render(hbs`
-      //   {{#frost-viz/scale/tick}}
-      //     template content
-      //   {{/frost-viz/scale/tick}}
-      // `);
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
-      this.render(hbs`{{frost-viz/scale/tick}}`)
-      expect(this.$()).to.have.length(1)
-    })
-  }
-)
+const test = integration('frost-viz/scale/tick')
+describe(test.label, function () {
+  test.setup()
+
+  it('renders', function () {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
+    // Template block usage:
+    // this.render(hbs`
+    //   {{#frost-viz/scale/tick}}
+    //     template content
+    //   {{/frost-viz/scale/tick}}
+    // `);
+
+    this.render(hbs`{{frost-viz/scale/tick}}`)
+    expect(this.$()).to.have.length(1)
+  })
+})

--- a/tests/integration/components/frost-viz/scale/tick/label-test.js
+++ b/tests/integration/components/frost-viz/scale/tick/label-test.js
@@ -1,30 +1,25 @@
 /* jshint expr:true */
-import { expect } from 'chai'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
+import {expect} from 'chai'
 import hbs from 'htmlbars-inline-precompile'
+import {describe, it} from 'mocha'
 
-describeComponent(
-  'frost-viz/scale/tick/label',
-  'Integration: FrostVizScaleTickLabelComponent',
-  {
-    integration: true
-  },
-  function () {
-    it('renders', function () {
-      // Set any properties with this.set('myProperty', 'value');
-      // Handle any actions with this.on('myAction', function(val) { ... });
-      // Template block usage:
-      // this.render(hbs`
-      //   {{#frost-viz/scale/tick/label}}
-      //     template content
-      //   {{/frost-viz/scale/tick/label}}
-      // `);
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
-      this.render(hbs`{{frost-viz/scale/tick/label}}`)
-      expect(this.$()).to.have.length(1)
-    })
-  }
-)
+const test = integration('frost-viz/scale/tick/label')
+describe(test.label, function () {
+  test.setup()
+
+  it('renders', function () {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
+    // Template block usage:
+    // this.render(hbs`
+    //   {{#frost-viz/scale/tick/label}}
+    //     template content
+    //   {{/frost-viz/scale/tick/label}}
+    // `);
+
+    this.render(hbs`{{frost-viz/scale/tick/label}}`)
+    expect(this.$()).to.have.length(1)
+  })
+})

--- a/tests/integration/components/frost-viz/scope-test.js
+++ b/tests/integration/components/frost-viz/scope-test.js
@@ -1,30 +1,25 @@
 /* jshint expr:true */
-import { expect } from 'chai'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
+import {expect} from 'chai'
 import hbs from 'htmlbars-inline-precompile'
+import {describe, it} from 'mocha'
 
-describeComponent(
-  'frost-viz/scope',
-  'Integration: FrostVizScopeComponent',
-  {
-    integration: true
-  },
-  function () {
-    it('renders', function () {
-      // Set any properties with this.set('myProperty', 'value');
-      // Handle any actions with this.on('myAction', function(val) { ... });
-      // Template block usage:
-      // this.render(hbs`
-      //   {{#frost-viz/scope}}
-      //     template content
-      //   {{/frost-viz/scope}}
-      // `);
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
-      this.render(hbs`{{frost-viz/scope}}`)
-      expect(this.$()).to.have.length(1)
-    })
-  }
-)
+const test = integration('frost-viz/scope')
+describe(test.label, function () {
+  test.setup()
+
+  it('renders', function () {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
+    // Template block usage:
+    // this.render(hbs`
+    //   {{#frost-viz/scope}}
+    //     template content
+    //   {{/frost-viz/scope}}
+    // `);
+
+    this.render(hbs`{{frost-viz/scope}}`)
+    expect(this.$()).to.have.length(1)
+  })
+})

--- a/tests/integration/components/frost-viz/support/expose-test.js
+++ b/tests/integration/components/frost-viz/support/expose-test.js
@@ -1,30 +1,25 @@
 /* jshint expr:true */
-import { expect } from 'chai'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
+import {expect} from 'chai'
 import hbs from 'htmlbars-inline-precompile'
+import {describe, it} from 'mocha'
 
-describeComponent(
-  'frost-viz/support/expose',
-  'Integration: FrostVizSupportExposeComponent',
-  {
-    integration: true
-  },
-  function () {
-    it.skip('renders', function () {
-      // Set any properties with this.set('myProperty', 'value');
-      // Handle any actions with this.on('myAction', function(val) { ... });
-      // Template block usage:
-      // this.render(hbs`
-      //   {{#frost-viz/support/expose}}
-      //     template content
-      //   {{/frost-viz/support/expose}}
-      // `);
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
-      this.render(hbs`{{frost-viz/support/expose}}`)
-      expect(this.$()).to.have.length(1)
-    })
-  }
-)
+const test = integration('frost-viz/support/expose')
+describe(test.label, function () {
+  test.setup()
+
+  it.skip('renders', function () {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
+    // Template block usage:
+    // this.render(hbs`
+    //   {{#frost-viz/support/expose}}
+    //     template content
+    //   {{/frost-viz/support/expose}}
+    // `);
+
+    this.render(hbs`{{frost-viz/support/expose}}`)
+    expect(this.$()).to.have.length(1)
+  })
+})

--- a/tests/integration/components/frost-viz/transform/cartesian-test.js
+++ b/tests/integration/components/frost-viz/transform/cartesian-test.js
@@ -1,30 +1,25 @@
 /* jshint expr:true */
-import { expect } from 'chai'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
+import {expect} from 'chai'
 import hbs from 'htmlbars-inline-precompile'
+import {describe, it} from 'mocha'
 
-describeComponent(
-  'frost-viz/transform/cartesian',
-  'Integration: FrostVizTransformCartesianComponent',
-  {
-    integration: true
-  },
-  function () {
-    it.skip('renders', function () {
-      // Set any properties with this.set('myProperty', 'value');
-      // Handle any actions with this.on('myAction', function(val) { ... });
-      // Template block usage:
-      // this.render(hbs`
-      //   {{#frost-viz/transform/cartesian}}
-      //     template content
-      //   {{/frost-viz/transform/cartesian}}
-      // `);
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
-      this.render(hbs`{{frost-viz/transform/cartesian}}`)
-      expect(this.$()).to.have.length(1)
-    })
-  }
-)
+const test = integration('frost-viz/transform/cartesian')
+describe(test.label, function () {
+  test.setup()
+
+  it.skip('renders', function () {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
+    // Template block usage:
+    // this.render(hbs`
+    //   {{#frost-viz/transform/cartesian}}
+    //     template content
+    //   {{/frost-viz/transform/cartesian}}
+    // `);
+
+    this.render(hbs`{{frost-viz/transform/cartesian}}`)
+    expect(this.$()).to.have.length(1)
+  })
+})

--- a/tests/unit/helpers/frost-viz/binding-test.js
+++ b/tests/unit/helpers/frost-viz/binding-test.js
@@ -1,11 +1,8 @@
-// import { expect } from 'chai'
-import {
-  describe,
-  it
-} from 'mocha'
+// import {expect} from 'chai'
 // import {
 //   frostVizBinding
 // } from 'ember-frost-viz/helpers/frost-viz/binding'
+import {describe, it} from 'mocha'
 
 describe('FrostVizBindingHelper', function () {
   it('works', function () {

--- a/tests/unit/helpers/frost-viz/dimension/linear-test.js
+++ b/tests/unit/helpers/frost-viz/dimension/linear-test.js
@@ -1,11 +1,8 @@
-// import { expect } from 'chai'
-import {
-  describe,
-  it
-} from 'mocha'
+// import {expect} from 'chai'
 // import {
 //   frostVizDimensionLinear
 // } from 'ember-frost-viz/helpers/frost-viz/dimension/linear'
+import {describe, it} from 'mocha'
 
 describe('FrostVizDimensionLinearHelper', function () {
   // Replace this with your real tests.

--- a/tests/unit/helpers/frost-viz/dimension/log-test.js
+++ b/tests/unit/helpers/frost-viz/dimension/log-test.js
@@ -1,11 +1,8 @@
-// import { expect } from 'chai'
-import {
-  describe,
-  it
-} from 'mocha'
+// import {expect} from 'chai'
 // import {
 //   frostVizDimensionLog
 // } from 'ember-frost-viz/helpers/frost-viz/dimension/log'
+import {describe, it} from 'mocha'
 
 describe('FrostVizDimensionLogHelper', function () {
   // Replace this with your real tests.

--- a/tests/unit/helpers/frost-viz/dimension/time-test.js
+++ b/tests/unit/helpers/frost-viz/dimension/time-test.js
@@ -1,11 +1,8 @@
-// import { expect } from 'chai'
-import {
-  describe,
-  it
-} from 'mocha'
+// import {expect} from 'chai'
 // import {
 //   frostVizDimensionTime
 // } from 'ember-frost-viz/helpers/frost-viz/dimension/time'
+import {describe, it} from 'mocha'
 
 describe('FrostVizDimensionTimeHelper', function () {
   // Replace this with your real tests.

--- a/tests/unit/helpers/frost-viz/format/default-test.js
+++ b/tests/unit/helpers/frost-viz/format/default-test.js
@@ -1,11 +1,8 @@
-// import { expect } from 'chai'
-import {
-  describe,
-  it
-} from 'mocha'
+// import {expect} from 'chai'
 // import {
 //   frostVizFormatDefault
 // } from 'ember-frost-viz/helpers/frost-viz/format/default'
+import {describe, it} from 'mocha'
 
 describe('FrostVizFormatDefaultHelper', function () {
   // Replace this with your real tests.

--- a/tests/unit/helpers/frost-viz/format/numeric-test.js
+++ b/tests/unit/helpers/frost-viz/format/numeric-test.js
@@ -1,11 +1,8 @@
-// import { expect } from 'chai'
-import {
-  describe,
-  it
-} from 'mocha'
+// import {expect} from 'chai'
 // import {
 //   frostVizFormatNumeric
 // } from 'ember-frost-viz/helpers/frost-viz/format/numeric'
+import {describe, it} from 'mocha'
 
 describe('FrostVizFormatNumericHelper', function () {
   // Replace this with your real tests.

--- a/tests/unit/helpers/frost-viz/format/time-test.js
+++ b/tests/unit/helpers/frost-viz/format/time-test.js
@@ -1,11 +1,8 @@
-// import { expect } from 'chai'
-import {
-  describe,
-  it
-} from 'mocha'
+// import {expect} from 'chai'
 // import {
 //   frostVizFormatTime
 // } from 'ember-frost-viz/helpers/frost-viz/format/time'
+import {describe, it} from 'mocha'
 
 describe('FrostVizFormatTimeHelper', function () {
   // Replace this with your real tests.

--- a/tests/unit/helpers/frost-viz/math-test.js
+++ b/tests/unit/helpers/frost-viz/math-test.js
@@ -1,12 +1,7 @@
 /* jshint expr:true */
-import { expect } from 'chai'
-import {
-  describe,
-  it
-} from 'mocha'
-import {
-  math
-} from 'ember-frost-viz/helpers/frost-viz/math'
+import {expect} from 'chai'
+import {math} from 'ember-frost-viz/helpers/frost-viz/math'
+import {describe, it} from 'mocha'
 
 describe('FrostVizMathHelper', function () {
   // Replace this with your real tests.

--- a/tests/unit/helpers/frost-viz/support/apply-test.js
+++ b/tests/unit/helpers/frost-viz/support/apply-test.js
@@ -1,11 +1,8 @@
-// import { expect } from 'chai'
-import {
-  describe,
-  it
-} from 'mocha'
+// import {expect} from 'chai'
 // import {
 //   frostVizSupportApply
 // } from 'ember-frost-viz/helpers/frost-viz/support/apply'
+import {describe, it} from 'mocha'
 
 describe('FrostVizSupportApplyHelper', function () {
   // Replace this with your real tests.

--- a/tests/unit/helpers/frost-viz/support/to-json-test.js
+++ b/tests/unit/helpers/frost-viz/support/to-json-test.js
@@ -1,10 +1,8 @@
-import {
-  describe,
-  it
-} from 'mocha'
+// import {expect} from 'chai'
 // import {
 //   frostVizSupportToJson
 // } from 'ember-frost-viz/helpers/frost-viz/support/to-json'
+import {describe, it} from 'mocha'
 
 describe('FrostVizSupportToJsonHelper', function () {
   // Replace this with your real tests.

--- a/tests/unit/utils/computed-rectangle-test.js
+++ b/tests/unit/utils/computed-rectangle-test.js
@@ -1,9 +1,6 @@
-// import { expect } from 'chai'
-import {
-  describe,
-  it
-} from 'mocha'
+// import {expect} from 'chai'
 // import computedRectangle from 'ember-frost-viz/utils/computed-rectangle'
+import {describe, it} from 'mocha'
 
 describe('computedRectangle', function () {
   // Replace this with your real tests.

--- a/tests/unit/utils/frost-viz-data-transform-test.js
+++ b/tests/unit/utils/frost-viz-data-transform-test.js
@@ -1,9 +1,6 @@
-// import { expect } from 'chai'
-import {
-  describe,
-  it
-} from 'mocha'
+// import {expect} from 'chai'
 // import frostVizDataTransform from 'ember-frost-viz/utils/frost-viz-data-transform'
+import {describe, it} from 'mocha'
 
 describe('frostVizDataTransform', function () {
   // Replace this with your real tests.

--- a/tests/unit/utils/frost-viz-rectangle-test.js
+++ b/tests/unit/utils/frost-viz-rectangle-test.js
@@ -1,9 +1,6 @@
-// import { expect } from 'chai'
-import {
-  describe,
-  it
-} from 'mocha'
+// import {expect} from 'chai'
 // import frostVizRectangle from 'ember-frost-viz/utils/frost-viz-rectangle'
+import {describe, it} from 'mocha'
 
 describe('frostVizRectangle', function () {
   // Replace this with your real tests.

--- a/tests/unit/utils/frost-viz-set-operations-test.js
+++ b/tests/unit/utils/frost-viz-set-operations-test.js
@@ -1,9 +1,6 @@
-// import { expect } from 'chai'
-import {
-  describe,
-  it
-} from 'mocha'
+// import {expect} from 'chai'
 // import frostVizSetOperations from 'ember-frost-viz/utils/frost-viz-set-operations'
+import {describe, it} from 'mocha'
 
 describe('frostVizSetOperations', function () {
   // Replace this with your real tests.

--- a/tests/unit/utils/polyfill-math-sign-test.js
+++ b/tests/unit/utils/polyfill-math-sign-test.js
@@ -1,9 +1,6 @@
-// import { expect } from 'chai'
-import {
-  describe,
-  it
-} from 'mocha'
+// import {expect} from 'chai'
 // import polyfillMathSign from 'ember-frost-viz/utils/polyfill-math-sign'
+import {describe, it} from 'mocha'
 
 describe('polyfillMathSign', function () {
   // Replace this with your real tests.


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [X] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Closes: https://github.com/ciena-frost/ember-frost-viz/issues/29

# CHANGELOG
* **Updated** integration/unit tests to remove the deprecated use of `describeComponent()`
* **Updated** ember-test-utils version to latest
